### PR TITLE
fix API errors path resolver

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -96,7 +96,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -108,7 +108,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1004
                   text: 'not found'
@@ -118,7 +118,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
         '500':
           description: 'Server Error'
           content:
@@ -126,7 +126,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -199,7 +199,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               examples:
                 example1:
                   value:
@@ -256,7 +256,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -268,7 +268,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1004
                   text: 'not found'
@@ -278,7 +278,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
         '500':
           description: 'Server Error'
           content:
@@ -286,7 +286,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -350,7 +350,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               examples:
                 invalidArgument:
                   value:
@@ -375,7 +375,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1004
                   text: 'not found'
@@ -609,7 +609,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -619,7 +619,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
         '500':
           description: 'Server Error'
           content:
@@ -627,7 +627,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -672,7 +672,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -684,7 +684,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -696,7 +696,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -748,7 +748,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -760,7 +760,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -770,7 +770,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
               examples:
                 typeMismatch:
                   value:
@@ -809,7 +809,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -940,7 +940,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 2001
                   text: 'invalid argument'
@@ -1063,7 +1063,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 2005
                   text: 'value too long'
@@ -1075,7 +1075,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -1087,7 +1087,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1004
                   text: 'not found'
@@ -1097,7 +1097,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
         '500':
           description: 'Server Error'
           content:
@@ -1105,7 +1105,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -1161,7 +1161,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1004
                   text: 'not found'
@@ -1288,7 +1288,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 2000
                   text: 'missing argument'
@@ -1341,7 +1341,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 2000
                   text: 'missing argument'
@@ -1421,7 +1421,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 2001
                   text: 'invalid argument'
@@ -1488,7 +1488,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 2000
                   text: 'missing argument'
@@ -1541,7 +1541,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 2000
                   text: 'missing argument'
@@ -1698,7 +1698,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1008
                   text: 'access denied'
@@ -1743,7 +1743,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1008
                   text: 'invalid url'
@@ -1857,7 +1857,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 2002
                   text: 'out of range'
@@ -1925,7 +1925,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
                 example:
                   - code: 2034
                     text: 'campaign already exists'
@@ -1939,7 +1939,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -1949,7 +1949,7 @@ paths:
           content:
             'content-type: application/json; charset=utf-8':
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
         '500':
           description: 'Server Error'
           content:
@@ -1957,7 +1957,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -2017,7 +2017,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -2027,7 +2027,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
         '500':
           description: 'Server Error'
           content:
@@ -2035,7 +2035,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -2095,7 +2095,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -2105,7 +2105,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
         '500':
           description: 'Server Error'
           content:
@@ -2113,7 +2113,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -2181,7 +2181,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -2191,7 +2191,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
         '500':
           description: 'Server Error'
           content:
@@ -2199,7 +2199,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -2286,7 +2286,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -2296,7 +2296,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
         '500':
           description: 'Server Error'
           content:
@@ -2304,7 +2304,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -2368,7 +2368,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1004
                   text: 'not found'
@@ -2380,7 +2380,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -2390,7 +2390,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
         '500':
           description: 'Server Error'
           content:
@@ -2398,7 +2398,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -2461,7 +2461,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1004
                   text: 'not found'
@@ -2473,7 +2473,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1009
                   text: 'missing token'
@@ -2483,7 +2483,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './errors.yaml/#/components/schemas/NotSupportedError'
+                $ref: './errors.yaml#/components/schemas/NotSupportedError'
         '500':
           description: 'Server Error'
           content:
@@ -2491,7 +2491,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                 - code: 1000
                   text: 'internal error'
@@ -2581,7 +2581,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                   - code: 2000
                     text: 'missing argument'
@@ -2750,7 +2750,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               examples:
                 missingArgument:
                   value:
@@ -2777,7 +2777,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
                 example:
                   - code: 2007
                     text: 'unsupported format'
@@ -3093,7 +3093,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               examples:
                 missingArgument1:
                   value:
@@ -3119,7 +3119,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: './errors.yaml/#/components/schemas/ApiResponseError'
+                  $ref: './errors.yaml#/components/schemas/ApiResponseError'
               example:
                   - code: 1000
                     text: 'internal error'


### PR DESCRIPTION
Not sure why but when the doc is rendered, I get the following errors (doesn't happen locally):

```
Resolver error at paths./ad/{adId}.put.responses.400.content.application/sellside.error-v1+json; charset=UTF-8.schema.items.$ref
Could not resolve reference:
Resolver error at paths./ad/{adId}.put.responses.401.content.application/sellside.error-v1+json; charset=UTF-8.schema.items.$ref
Could not resolve reference:
Resolver error at paths./ad/{adId}.put.responses.404.content.application/sellside.error-v1+json; charset=UTF-8.schema.items.$ref
Could not resolve reference:
Resolver error at paths./ad/{adId}.put.responses.406.content.application/json.schema.$ref
Could not resolve reference:
Resolver error at paths./ad/{adId}.put.responses.500.content.application/sellside.error-v1+json; charset=UTF-8.schema.items.$ref
Could not resolve reference:
```
It only seems to happen with references to the `errors.yaml` file.
This is an attempt to fix it, since I cannot reproduce locally.